### PR TITLE
Add Custom Field for storing linked GrowthBook objects

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -15,6 +15,31 @@ modules:
       resolver:
         function: resolver
       useAsConfig: true
+  jira:customField:
+    - key: growthbook-custom-field
+      name: GrowthBook Link
+      description: The connected GrowthBook object (Feature or Experiment) for a single issue
+      type: object
+      readOnly: true
+      view:
+        formatter:
+          expression: "`${value.gbLink}`"
+      schema:
+        properties:
+          objectType:
+            type: string
+            enum: ["feature", "experiment"]
+            searchAlias: type
+          objectId:
+            type: string
+            searchAlias: id
+          objectName:
+            type: string
+            searchAlias: name
+          gbLink:
+            type: string
+            searchAlias: link
+        required: ["objectType", "objectId", "objectName", "gbLink"]
   function:
     - key: resolver
       handler: index.handler
@@ -32,6 +57,8 @@ app:
 permissions:
   scopes:
     - storage:app
+    - read:jira-work
+    - write:app-data:jira
   external:
     fetch:
       client:

--- a/src/frontend/configure/index.tsx
+++ b/src/frontend/configure/index.tsx
@@ -55,10 +55,7 @@ const App = () => {
       </Box>
       <Box>
         {error ? (
-          <Text>
-            <Icon label="" glyph="cross" />
-            There was an error:
-          </Text>
+          <Text>There was an error:</Text>
         ) : saving ? (
           <Text>
             <Spinner />

--- a/src/frontend/hooks/useAppSettingsContext.tsx
+++ b/src/frontend/hooks/useAppSettingsContext.tsx
@@ -20,7 +20,6 @@ interface AppSettings {
   persistedState: Record<string, any>;
   updatePersistedState: (key: string, value: any) => void;
   customFieldId: string | undefined;
-  setCustomFieldId: (value: string) => void;
 }
 
 const AppSettingsContext = createContext<AppSettings | null>(null);
@@ -160,7 +159,6 @@ export const AppSettingsContextProvider = ({
         persistedState,
         updatePersistedState,
         customFieldId,
-        setCustomFieldId,
       }}
     >
       {children}

--- a/src/frontend/widget/GrowthBookLink.tsx
+++ b/src/frontend/widget/GrowthBookLink.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Link, Icon, Inline } from "@forge/react";
 import { ForgeNode } from "@forge/react/out/types";
-import { GB_APP_ORIGIN } from "../../utils/consts";
+import { getGbLink } from "../../utils";
 
 interface LinkProps {
   path?: string;
@@ -15,7 +15,7 @@ export default function GrowthBookLink({
   hideIcon,
 }: LinkProps) {
   return (
-    <Link openNewTab href={new URL(path || "", GB_APP_ORIGIN).toString()}>
+    <Link openNewTab href={getGbLink(path)}>
       <Inline shouldWrap={false} alignBlock="center" space="space.025">
         {children}
         {!hideIcon && (

--- a/src/frontend/widget/IssuePanel.tsx
+++ b/src/frontend/widget/IssuePanel.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import LoadingSpinner from "./LoadingSpinner";
-import { ErrorMessage } from "@forge/react";
+import { Button, ErrorMessage, Inline } from "@forge/react";
 import { useIssueContext } from "../hooks/useIssueContext";
 import UnlinkedIssue from "./UnlinkedIssue";
 import LinkedObjectInfo from "./LinkedObjectInfo";
@@ -8,6 +8,7 @@ import LinkedObjectInfo from "./LinkedObjectInfo";
 export default function IssuePanel() {
   const {
     issueData,
+    setIssueData,
     loading: issueDataLoading,
     error: issueDataError,
   } = useIssueContext();
@@ -16,7 +17,19 @@ export default function IssuePanel() {
     return <LoadingSpinner text="Loading your saved data..." />;
 
   if (issueDataError) {
-    return <ErrorMessage>{issueDataError}</ErrorMessage>;
+    return (
+      <Inline
+        shouldWrap
+        alignBlock="center"
+        space="space.150"
+        rowSpace="space.0"
+      >
+        <ErrorMessage>{issueDataError}</ErrorMessage>
+        <Button onClick={() => setIssueData({})} spacing="compact">
+          Clear Data
+        </Button>
+      </Inline>
+    );
   }
 
   if (!issueData.linkedObject) {

--- a/src/frontend/widget/LinkedObjectInfo.tsx
+++ b/src/frontend/widget/LinkedObjectInfo.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { LinkedObject } from "src/utils/types";
 import ExperimentDisplay from "./ExperimentDisplay";
 import FeatureDisplay from "./FeatureDisplay";

--- a/src/frontend/widget/LinkedObjectInfo.tsx
+++ b/src/frontend/widget/LinkedObjectInfo.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React from "react";
 import { LinkedObject } from "src/utils/types";
 import ExperimentDisplay from "./ExperimentDisplay";
 import FeatureDisplay from "./FeatureDisplay";

--- a/src/frontend/widget/UnlinkedIssue.tsx
+++ b/src/frontend/widget/UnlinkedIssue.tsx
@@ -71,7 +71,11 @@ export default function UnlinkedIssue() {
             ? "feature"
             : "experiment";
           setIssueData({
-            linkedObject: { type, id: selectedOption.value },
+            linkedObject: {
+              type,
+              id: selectedOption.value,
+              name: selectedOption.label,
+            },
           });
         }}
         placeholder="Choose a feature or experiment to link to this issue"

--- a/src/frontend/widget/index.tsx
+++ b/src/frontend/widget/index.tsx
@@ -59,12 +59,12 @@ const App = () => {
 
 ForgeReconciler.render(
   <React.StrictMode>
-    <AppSettingsContextProvider>
-      <JiraContextProvider>
+    <JiraContextProvider>
+      <AppSettingsContextProvider>
         <IssueContextProvider>
           <App />
         </IssueContextProvider>
-      </JiraContextProvider>
-    </AppSettingsContextProvider>
+      </AppSettingsContextProvider>
+    </JiraContextProvider>
   </React.StrictMode>
 );

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
+import { GB_APP_ORIGIN } from "./consts";
 import { Experiment } from "./types";
 
 // Initialize const once to avoid unnecessary searching of locale db
@@ -12,6 +13,10 @@ const dateTimeFormatter = new Intl.DateTimeFormat(undefined, {
 export function formatDate(timestamp: string) {
   const d = new Date(timestamp);
   return dateTimeFormatter.format(d);
+}
+
+export function getGbLink(path?: string) {
+  return new URL(path || "", GB_APP_ORIGIN).toString();
 }
 
 export function getWinningVariant(experiment: Experiment): string | undefined {

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -5,6 +5,7 @@ const APP_SETTINGS_KEY = "GB_APP_SETTINGS";
 const APP_SETTINGS_DEFAULTS: StoredAppSettings = {
   apiKey: "",
   persistedState: {},
+  customFieldId: "",
 };
 
 export async function getAppSettings() {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -15,6 +15,11 @@ export function isStoredAppSettings(
     typecast.persistedState === null
   )
     return false;
+  if (
+    typecast.customFieldId !== undefined &&
+    typeof typecast.customFieldId !== "string"
+  )
+    return false;
 
   return true;
 }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,6 +1,7 @@
 export interface StoredAppSettings {
   apiKey: string;
   persistedState: Record<string, any>;
+  customFieldId?: string;
 }
 
 export function isStoredAppSettings(
@@ -21,11 +22,13 @@ export function isStoredAppSettings(
 interface LinkedFeature {
   type: "feature";
   id: string;
+  name?: string;
 }
 
 interface LinkedExperiment {
   type: "experiment";
   id: string;
+  name?: string;
 }
 
 export type LinkedObject = LinkedFeature | LinkedExperiment;


### PR DESCRIPTION
A customer requested we add a Custom Field to Jira to hold the GB link so it can be filtered on in JQL and be more visible in general when viewing multiple issues at once.

This PR adds a new custom field, which can optionally be added to projects by Jira admins. Once added, any updates to link an experiment/feature to an issue will also store that link in the custom field. The field is optional, so no errors are thrown if customers opt not to add the field to their projects.

- Closes #2

### Screenshots
Adding field experience in Jira settings
<img width="830" height="1104" alt="image" src="https://github.com/user-attachments/assets/0cca349e-0899-4efb-a216-4f8a7748b1d1" />

<img width="1329" height="856" alt="image" src="https://github.com/user-attachments/assets/8e9a33c0-ea5c-4bdf-b195-c8f87d8b8de2" />

Appearance on Issue modal (customizable location)
<img width="1466" height="990" alt="image" src="https://github.com/user-attachments/assets/17cc1895-70f1-405c-a144-d5e6714367b9" />
